### PR TITLE
Add retryStrategy and rename to data-processing

### DIFF
--- a/templates/ls-geomad-annual-0-1-0.yaml
+++ b/templates/ls-geomad-annual-0-1-0.yaml
@@ -16,12 +16,12 @@ spec:
     annotations:
       karpenter.sh/do-not-disrupt: "true"
   nodeSelector:
-    karpenter.sh/capacity-type: "spot" # Just to be explicit. In dep-terraform, the data-production nodepool can only pick spot instances
-    dep/workload: data-production
+    karpenter.sh/capacity-type: "spot" # Just to be explicit. In dep-terraform, the data-processing nodepool can only pick spot instances
+    dep/workload: data-processing
   tolerations:
     - key: dep/workload
       operator: Equal
-      value: data-production
+      value: data-processing
       effect: NoSchedule
   arguments:
     parameters:

--- a/templates/ls-geomad-annual-0-1-0.yaml
+++ b/templates/ls-geomad-annual-0-1-0.yaml
@@ -13,8 +13,6 @@ spec:
   podMetadata:
     labels:
       app: ls-geomad
-    annotations:
-      karpenter.sh/do-not-disrupt: "true"
   nodeSelector:
     karpenter.sh/capacity-type: "spot" # Just to be explicit. In dep-terraform, the data-production nodepool can only pick spot instances
     dep/workload: data-production
@@ -66,8 +64,8 @@ spec:
         imagePullPolicy: IfNotPresent
         resources:
           requests:
-            memory: 100Mi
-            cpu: 1.0
+            memory: 10Gi
+            cpu: 8
         command: [ldn]
         args:
           - print-tasks

--- a/templates/ls-geomad-annual-0-1-0.yaml
+++ b/templates/ls-geomad-annual-0-1-0.yaml
@@ -13,6 +13,8 @@ spec:
   podMetadata:
     labels:
       app: ls-geomad
+    annotations:
+      karpenter.sh/do-not-disrupt: "true"
   nodeSelector:
     karpenter.sh/capacity-type: "spot" # Just to be explicit. In dep-terraform, the data-production nodepool can only pick spot instances
     dep/workload: data-production
@@ -80,6 +82,15 @@ spec:
           - name: tile-id
           - name: year
           - name: region
+      retryStrategy:
+        limit: "3"
+        retryPolicy: OnFailure
+        backoff:
+          duration: "5s"
+          factor: 2
+          maxDuration: "5m"
+        # Don't retry OOMKills (exit 137)
+        expression: "asInt(lastRetry.exitCode) != 137"
       container:
         image: "{{ workflow.parameters.image-name }}:{{ workflow.parameters.image-tag }}"
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Removes the karpenter.sh/do-not-disrupt annotation which is counterproductive on spot nodes, spot instances can be reclaimed by AWS at any time regardless. The annotation only delays karpenter's own consolidation/rotation. 

Bumped print-tasks resources to match process-geomad. This keeps them on the same node. In testing, print-tasks was landing on nodes that were too small for process-geomad, which triggered the creation of a second node.