### PR TITLE
Bump GitHub Actions

### DIFF
--- a/.github/workflows/ldn-lint-build-test-push.yml
+++ b/.github/workflows/ldn-lint-build-test-push.yml
@@ -5,6 +5,11 @@
 # GitHub Container Registry (GHCR) on push to main or release.
 # PRs to any branch get linted, built, and tested,
 # but the image is only pushed when the code actually lands on main.
+#
+# Action SHAs pinned for supply chain security.
+# To update: visit each action's releases page, click the tag, and copy
+# the full 40-char commit SHA from the tag's commit link.
+# e.g. https://github.com/actions/checkout/releases/tag/v6.0.2
 name: LDN lint, build, test, and push Docker image to GHCR
 
 env:
@@ -44,7 +49,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: astral-sh/ruff-action@v3
         with:
           src: "ldn"
@@ -56,15 +63,16 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
         if: github.ref == 'refs/heads/main' || github.event_name == 'release'
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -77,7 +85,7 @@ jobs:
           echo "VERSION=$(git describe --tags --always)" >> $GITHUB_OUTPUT
 
       - name: Build image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           load: true

--- a/.github/workflows/ldn-lint-build-test-push.yml
+++ b/.github/workflows/ldn-lint-build-test-push.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: astral-sh/ruff-action@v3
+      - uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
         with:
           src: "ldn"
 


### PR DESCRIPTION
Bump GitHub Actions to newer versions to avoid the Node.js v20 warning. Pin to a SHA hash and don't persist git credentials to avoid security risk