### PR TITLE
Geomad count feature and minor classification improvements

### DIFF
--- a/ldn/classify.py
+++ b/ldn/classify.py
@@ -791,6 +791,9 @@ def run_classify_task(
     overwrite: Annotated[bool, typer.Option()],
     probability_threshold: float,
     nodata_value: int,
+    memory_limit: str,
+    n_workers: int,
+    threads_per_worker: int,
 ) -> None:
     """Run LULC prediction for a single tile and year, writing results to S3.
 
@@ -812,6 +815,9 @@ def run_classify_task(
         overwrite: If True, overwrite existing output.
         probability_threshold: Confidence threshold (0-100) for the binary mask.
         nodata_value: Integer nodata value for output bands.
+        memory_limit: Per-worker Dask memory limit.
+        n_workers: Number of Dask workers.
+        threads_per_worker: Number of threads per Dask worker.
     """
     logger.info(
         f"Starting processing. Tile ID: {tile_id}, Year: {datetime}, "
@@ -883,6 +889,11 @@ def run_classify_task(
         "Either item does not exist or overwrite is True, proceeding with processing."
     )
 
+    logger.info(
+        f"Dask config: n_workers={n_workers}, threads_per_worker={threads_per_worker}, "
+        f"memory_limit={memory_limit}, xy_chunk_size={xy_chunk_size}"
+    )
+
     searcher = StacGeoparquetSearcher(
         stac_geoparquet_url=geomad_stac_geoparquet_url,
         datetime=datetime,
@@ -906,9 +917,14 @@ def run_classify_task(
 
     stac_creator = StacCreator(itempath=itempath, with_raster=True)
 
-    dask_client = DaskClient(n_workers=4, threads_per_worker=16, memory_limit="12GB")
+    dask_client = DaskClient(
+        n_workers=n_workers,
+        threads_per_worker=threads_per_worker,
+        memory_limit=memory_limit,
+    )
+    logger.info("Started dask client")
+
     try:
-        logger.info("Started dask client")
         paths = Task(
             itempath=itempath,
             id=tile_id_tuple,

--- a/ldn/classify.py
+++ b/ldn/classify.py
@@ -784,7 +784,6 @@ def run_classify_task(
     region: Literal["pacific", "non-pacific"],
     output_bucket: str,
     output_prefix: str,
-    geomad_prefix: str,
     model_path: str,
     xy_chunk_size: int,
     asset_url_prefix: str | None,
@@ -806,7 +805,6 @@ def run_classify_task(
         region: Grid region, either "pacific" or "non-pacific".
         output_bucket: S3 bucket for output COGs, STAC metadata, and GeoMAD source data.
         output_prefix: Output prefix for paths (e.g. "dep" or "ci").
-        geomad_prefix: Dataset prefix for the GeoMAD geoparquet (e.g. "dep_ls_geomad").
         model_path: Path or URL to the trained joblib model.
         xy_chunk_size: Chunk size in pixels for lazy loading.
         asset_url_prefix: Optional URL prefix for STAC asset hrefs.

--- a/ldn/cli_classify.py
+++ b/ldn/cli_classify.py
@@ -6,7 +6,6 @@ import typer
 from ldn.classify import run_classify_task
 from ldn.utils import (
     AWS_REGION,
-    GEOMAD_DATASET_ID,
     GEOMAD_VERSION,
     MODEL_VERSION,
     LdnError,
@@ -16,7 +15,6 @@ from ldn.utils import (
     PACIFIC_OWNER,
     PREDICTION_VERSION,
     bucket_for_region,
-    dataset_prefix,
     owner_for_region,
 )
 
@@ -85,9 +83,9 @@ def run(
 
     # Resolve bucket and prefix based on region
     output_bucket = bucket_for_region(region, bucket_pacific, bucket_non_pacific)
-    owner = owner_for_region(region, owner_pacific, owner_non_pacific, product_owner)
-    output_prefix = owner
-    geomad_prefix = dataset_prefix(owner, GEOMAD_DATASET_ID)
+    output_prefix = owner_for_region(
+        region, owner_pacific, owner_non_pacific, product_owner
+    )
 
     run_classify_task(
         tile_id,
@@ -97,7 +95,6 @@ def run(
         region=region,
         output_bucket=output_bucket,
         output_prefix=output_prefix,
-        geomad_prefix=geomad_prefix,
         model_path=model_path,
         xy_chunk_size=xy_chunk_size,
         asset_url_prefix=asset_url_prefix,

--- a/ldn/cli_classify.py
+++ b/ldn/cli_classify.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Literal
+from typing import Annotated, Literal
 
 import typer
 
@@ -57,10 +57,6 @@ def run(
         f"https://s3.{AWS_REGION}.amazonaws.com/data.ldn.auspatious.com/models/{MODEL_VERSION}/pacific/2020/lulc_random_forest_model_pacific_2020.joblib",
         help="Model to use for prediction.",
     ),
-    xy_chunk_size: int = typer.Option(
-        1024,
-        help="Chunk size in pixels for x and y dimensions when predicting. Larger chunk sizes may be faster but use more memory.",
-    ),
     asset_url_prefix: str | None = typer.Option(None, help="Prefix for asset URLs."),
     decimated: bool = typer.Option(
         False,
@@ -77,6 +73,19 @@ def run(
         255,
         help="Value to use for NoData pixels in the output. Must be an integer between 0 and 255.",
     ),
+    memory_limit: Annotated[
+        str, typer.Option(help="Per-worker Dask memory limit.")
+    ] = "10GB",
+    n_workers: Annotated[int, typer.Option(help="Number of Dask workers.")] = 2,
+    threads_per_worker: Annotated[
+        int, typer.Option(help="Threads per Dask worker.")
+    ] = 4,
+    xy_chunk_size: Annotated[
+        int,
+        typer.Option(
+            help="Chunk size in pixels for x and y dimensions when predicting. Larger chunk sizes may be faster but use more memory."
+        ),
+    ] = 1024,
 ) -> None:
     if int(year) < 2000 or int(year) > 2025:
         raise LdnError("Year must be between 2000 and 2025.")
@@ -102,4 +111,7 @@ def run(
         overwrite=overwrite,
         probability_threshold=probability_threshold,
         nodata_value=nodata_value,
+        memory_limit=memory_limit,
+        n_workers=n_workers,
+        threads_per_worker=threads_per_worker,
     )

--- a/ldn/cli_geomad.py
+++ b/ldn/cli_geomad.py
@@ -48,6 +48,49 @@ EXIT_OOM = 42  # KilledWorker — retry with more resources
 EXIT_SKIP = 43  # too few scenes / no items — expected, don't retry
 
 
+def count_scenes(
+    tile_id: str = typer.Option(..., help="Tile ID to count scenes for."),
+    region: Literal["pacific", "non-pacific"] = typer.Option(
+        ..., help="Region tile is in."
+    ),
+    year: str = typer.Option(..., help="Year to count scenes for."),
+) -> int:
+    """Count (tier 1) scenes per tile and year. Precursor product to geomad creation."""
+
+    # Set up variables and check
+    tile_index = tuple(map(int, tile_id.split("_")))
+
+    grid = get_gridspec(region=region)
+    geobox = grid.tile_geobox(tile_index)
+
+    # Searcher finds STAC Items
+    searcher = PystacSearcher(
+        catalog=USGS_CATALOG,
+        collections=[USGS_COLLECTION],
+        datetime=year,
+        query={"landsat:collection_category": {"in": ["T1"]}},
+    )
+
+    items = searcher.search(geobox)
+    logger.info(f"Found {len(items)} tier 1 LS items for this tile/year")
+
+    # Loader loads the data from STAC Items.
+    loader = OdcLoader(
+        bands=["red"],  # Just need one band to count scenes.
+        chunks={"x": 256, "y": 256, "time": 1},
+        groupby="solar_day",
+        fail_on_error=False,  # We don't control the Landsat data so it may have issues, but we still want to load what we can.
+    )
+
+    items_grouped = loader.load(items, geobox)
+    count = len(items_grouped.time.values)
+    logger.info(
+        f"Loaded {count} tier 1 LS items for this tile/year (grouped by solar_day)"
+    )
+
+    return count
+
+
 @geomad_app.command()
 def run(
     tile_id: Annotated[str, typer.Option()],
@@ -106,25 +149,41 @@ def run(
         f"chunk={xy_chunk_size} geomad_threads={geomad_threads}",
     )
 
+    scene_count = count_scenes(tile_id=tile_id, year=year, region=region)
+    logger.info(f"Scene count (tier 1) for tile/year: {scene_count}")
+
     year_int = int(year)
     search_year = year
-    # If we're in the LS7 era, use a buffered window of data
-    if year_int <= 2012:
-        year_start = year_int - ls7_buffer_years
-        year_end = year_int + ls7_buffer_years
-        search_year = f"{year_start}/{year_end}"
-        typer.echo(
-            f"Using {ls7_buffer_years}-year buffered window for LS7 era: {search_year}"
+    search_kwargs = {"query": {"landsat:collection_category": {"in": ["T1"]}}}
+
+    min_scenes_threshold = (
+        20  # 20 should be enough. Otherwise add tier 2 and buffered window for LS7 era.
+    )
+    if scene_count <= min_scenes_threshold:
+        logger.info(
+            f"Scene count ({scene_count}) is less than {min_scenes_threshold}, using buffered search parameters to try to get more scenes."
         )
 
-    # For now, if we're in the Pacific, use both T1 and T2 data
-    # This may be necessary in other places too
-    search_kwargs = {"query": {"landsat:collection_category": {"in": ["T1"]}}}
-    if region == "pacific":
+        # If we're in the LS7 era, use a buffered window of data
         if year_int <= 2012:
-            # Searching for nothing gives us everything
-            typer.echo("Using both T1 and T2 data for Pacific for LS7 era")
-            search_kwargs = {}
+            year_start = year_int - ls7_buffer_years
+            year_end = year_int + ls7_buffer_years
+            search_year = f"{year_start}/{year_end}"
+            typer.echo(
+                f"Using {ls7_buffer_years}-year buffered window for LS7 era: {search_year}"
+            )
+
+        # For now, if we're in the Pacific, use both T1 and T2 data
+        # This may be necessary in other places too
+        if region == "pacific":
+            if year_int <= 2012:
+                # Searching for nothing gives us everything
+                typer.echo("Using both T1 and T2 data for Pacific for LS7 era")
+                search_kwargs = {}
+    else:
+        logger.info(
+            f"Scene count ({scene_count}) is greater than {min_scenes_threshold}, using default search parameters."
+        )
 
     # Set up variables and check
     tile_index = tuple(map(int, tile_id.split("_")))

--- a/ldn/cli_geomad.py
+++ b/ldn/cli_geomad.py
@@ -56,20 +56,17 @@ def count_scenes(
     year: str = typer.Option(..., help="Year to count scenes for."),
     include_t2: bool = typer.Option(
         False,
-        help="If True, include tier 2 scenes in the count. If False, only count tier 1 scenes. Defaults to False.",
+        help="If True, include tier 2 scenes in the count. Defaults to False (just tier 1).",
     ),
 ) -> int:
-    """Count (tier 1 or all) scenes per tile and year. Precursor product to geomad creation."""
+    """Count (tier 1 or all) scenes per tile and year."""
 
-    # Set up variables and check
     tile_index = tuple(map(int, tile_id.split("_")))
-
     grid = get_gridspec(region=region)
     geobox = grid.tile_geobox(tile_index)
 
     query = {} if include_t2 else {"landsat:collection_category": {"in": ["T1"]}}
 
-    # Searcher finds STAC Items
     searcher = PystacSearcher(
         catalog=USGS_CATALOG,
         collections=[USGS_COLLECTION],
@@ -77,23 +74,14 @@ def count_scenes(
         query=query,
     )
 
-    log_t2 = "(T1 and T2)" if include_t2 else "(T1 not including T2)"
-
     items = searcher.search(geobox)
-    logger.info(f"Found {len(items)} {log_t2} LS items for this tile/year")
 
-    # Loader loads the data from STAC Items.
-    loader = OdcLoader(
-        bands=["red"],  # Just need one band to count scenes.
-        chunks={"x": 256, "y": 256, "time": 1},
-        groupby="solar_day",
-        fail_on_error=False,  # We don't control the Landsat data so it may have issues, but we still want to load what we can.
-    )
+    dates = {item.datetime.date() for item in items}
+    count = len(dates)
 
-    items_grouped = loader.load(items, geobox)
-    count = len(items_grouped.time.values)
+    log_t2 = "(T1 and T2)" if include_t2 else "(T1 only)"
     logger.info(
-        f"Loaded {count} {log_t2} LS items for this tile/year (grouped by solar_day)"
+        f"Found {count} {log_t2} scenes for this tile/year (grouped by solar_day)"
     )
 
     return count

--- a/ldn/cli_geomad.py
+++ b/ldn/cli_geomad.py
@@ -54,8 +54,12 @@ def count_scenes(
         ..., help="Region tile is in."
     ),
     year: str = typer.Option(..., help="Year to count scenes for."),
+    include_t2: bool = typer.Option(
+        False,
+        help="If True, include tier 2 scenes in the count. If False, only count tier 1 scenes. Defaults to False.",
+    ),
 ) -> int:
-    """Count (tier 1) scenes per tile and year. Precursor product to geomad creation."""
+    """Count (tier 1 or all) scenes per tile and year. Precursor product to geomad creation."""
 
     # Set up variables and check
     tile_index = tuple(map(int, tile_id.split("_")))
@@ -63,16 +67,20 @@ def count_scenes(
     grid = get_gridspec(region=region)
     geobox = grid.tile_geobox(tile_index)
 
+    query = {} if include_t2 else {"landsat:collection_category": {"in": ["T1"]}}
+
     # Searcher finds STAC Items
     searcher = PystacSearcher(
         catalog=USGS_CATALOG,
         collections=[USGS_COLLECTION],
         datetime=year,
-        query={"landsat:collection_category": {"in": ["T1"]}},
+        query=query,
     )
 
+    log_t2 = "(T1 and T2)" if include_t2 else "(T1 not including T2)"
+
     items = searcher.search(geobox)
-    logger.info(f"Found {len(items)} tier 1 LS items for this tile/year")
+    logger.info(f"Found {len(items)} {log_t2} LS items for this tile/year")
 
     # Loader loads the data from STAC Items.
     loader = OdcLoader(
@@ -85,7 +93,7 @@ def count_scenes(
     items_grouped = loader.load(items, geobox)
     count = len(items_grouped.time.values)
     logger.info(
-        f"Loaded {count} tier 1 LS items for this tile/year (grouped by solar_day)"
+        f"Loaded {count} {log_t2} LS items for this tile/year (grouped by solar_day)"
     )
 
     return count
@@ -149,41 +157,52 @@ def run(
         f"chunk={xy_chunk_size} geomad_threads={geomad_threads}",
     )
 
-    scene_count = count_scenes(tile_id=tile_id, year=year, region=region)
-    logger.info(f"Scene count (tier 1) for tile/year: {scene_count}")
-
     year_int = int(year)
     search_year = year
     search_kwargs = {"query": {"landsat:collection_category": {"in": ["T1"]}}}
 
-    min_scenes_threshold = (
-        20  # 20 should be enough. Otherwise add tier 2 and buffered window for LS7 era.
+    min_scenes_threshold = 20
+
+    scene_count_without_t2 = count_scenes(
+        tile_id=tile_id, year=year, region=region, include_t2=False
     )
-    if scene_count <= min_scenes_threshold:
+    logger.info(f"Scene count (tier 1) for tile/year: {scene_count_without_t2}")
+
+    if scene_count_without_t2 >= min_scenes_threshold:
         logger.info(
-            f"Scene count ({scene_count}) is less than {min_scenes_threshold}, using buffered search parameters to try to get more scenes."
+            f"Scene count ({scene_count_without_t2}) is sufficient with T1 only."
         )
+        # search_kwargs already set to T1 only, search_year already set to year
 
-        # If we're in the LS7 era, use a buffered window of data
-        if year_int <= 2012:
-            year_start = year_int - ls7_buffer_years
-            year_end = year_int + ls7_buffer_years
-            search_year = f"{year_start}/{year_end}"
-            typer.echo(
-                f"Using {ls7_buffer_years}-year buffered window for LS7 era: {search_year}"
-            )
-
-        # For now, if we're in the Pacific, use both T1 and T2 data
-        # This may be necessary in other places too
-        if region == "pacific":
-            if year_int <= 2012:
-                # Searching for nothing gives us everything
-                typer.echo("Using both T1 and T2 data for Pacific for LS7 era")
-                search_kwargs = {}
     else:
         logger.info(
-            f"Scene count ({scene_count}) is greater than {min_scenes_threshold}, using default search parameters."
+            f"Scene count ({scene_count_without_t2}) is below {min_scenes_threshold}, trying with T2 too."
         )
+        scene_count_with_t2 = count_scenes(
+            tile_id=tile_id, year=year, region=region, include_t2=True
+        )
+
+        if scene_count_with_t2 >= min_scenes_threshold:
+            logger.info(
+                f"Scene count with T2 ({scene_count_with_t2}) is sufficient, using T1 and T2."
+            )
+            search_kwargs = {}  # Include T2
+
+        else:
+            logger.info(
+                f"Scene count with T2 ({scene_count_with_t2}) is still below {min_scenes_threshold}. Adding LS7 buffered temporal search as well as T1 and T2 data."
+            )
+            search_kwargs = {}  # Include T2
+
+            if year_int <= 2012:
+                year_start = year_int - ls7_buffer_years
+                year_end = year_int + ls7_buffer_years
+                search_year = f"{year_start}/{year_end}"
+                typer.echo(
+                    f"Using {ls7_buffer_years}-year buffered temporal search for LS7 era: {search_year}"
+                )
+            else:
+                logger.info("Not in LS7 era so not using buffered temporal search.")
 
     # Set up variables and check
     tile_index = tuple(map(int, tile_id.split("_")))

--- a/ldn/tests/test_cli_region_config.py
+++ b/ldn/tests/test_cli_region_config.py
@@ -173,7 +173,6 @@ class TestClassifyRegionConfig:
         kwargs = mock_run.call_args[1]
         assert kwargs["output_bucket"] == "custom-bucket"
         assert kwargs["output_prefix"] == "customorg"
-        assert kwargs["geomad_prefix"] == "customorg_ls_geomad"
 
     @patch("ldn.cli_classify.run_classify_task")
     def test_product_owner_overrides_in_classify(self, mock_run):
@@ -199,7 +198,6 @@ class TestClassifyRegionConfig:
         assert result.exit_code == 0, result.output
         kwargs = mock_run.call_args[1]
         assert kwargs["output_prefix"] == "override"
-        assert kwargs["geomad_prefix"] == "override_ls_geomad"
 
 
 class TestIndexToStacGeoparquetRegionConfig:

--- a/templates/ls-geomad-annual.yaml
+++ b/templates/ls-geomad-annual.yaml
@@ -100,7 +100,7 @@ spec:
           - name: tile-id
           - name: year
           - name: region
-      activeDeadlineSeconds: 1800 # 30 mins
+      activeDeadlineSeconds: 900 # 15 mins
       # Scale resources on retry.
       retryStrategy:
         limit: "1" # Just a single retry.

--- a/templates/ls-geomad-annual.yaml
+++ b/templates/ls-geomad-annual.yaml
@@ -100,13 +100,16 @@ spec:
           - name: tile-id
           - name: year
           - name: region
-      activeDeadlineSeconds: 1200 # 20 mins
-      # Scale resources on retry. Just a single retry.
+      activeDeadlineSeconds: 1800 # 30 mins
+      # Scale resources on retry.
       retryStrategy:
-        limit: "2"
-        retryPolicy: OnFailure
-        # Only retry on killer worker or OOM errors
-        expression: "asInt(lastRetry.exitCode) == 42 || asInt(lastRetry.exitCode) == 137 || (asInt(lastRetry.exitCode) == 143)"
+        limit: "1" # Just a single retry.
+        # Only retry on killer worker or OOM errors. Error means exit code is unavailable (kubernetes killed the pod).
+        expression: >-
+          asInt(lastRetry.exitCode) == 42 ||
+          asInt(lastRetry.exitCode) == 137 ||
+          asInt(lastRetry.exitCode) == 143 ||
+          lastRetry.status == "Error"
       # Pod memory needed = (n_workers * memory_limit) + scheduler_overhead + main_process_overhead
       # Pod CPU needed = (n_workers * threads_per_worker) + scheduler_threads
       podSpecPatch: |
@@ -137,12 +140,12 @@ spec:
           - --version
           - "{{ workflow.parameters.version }}"
           - --memory-limit
-          - "{{= asInt(retries) == 0 ? '6GB' : '12GB'}}"
+          - "{{= asInt(retries) == 0 ? '6GB' : '14GB'}}"
           - --n-workers
           - "2"
           - --threads-per-worker
           - "{{= asInt(retries) == 0 ? '4' : '8'}}"
           - --xy-chunk-size
-          - "800"
+          - "{{= asInt(retries) == 0 ? '800' : '1600'}}"
           - "{{ workflow.parameters.overwrite }}"
           - "{{ workflow.parameters.decimated }}"

--- a/templates/ls-lulc-classify-annual.yaml
+++ b/templates/ls-lulc-classify-annual.yaml
@@ -106,8 +106,7 @@ spec:
           - name: tile-id
           - name: year
           - name: region
-        # 15 minutes is more than enough time for a process to run.
-      activeDeadlineSeconds: 900
+      activeDeadlineSeconds: 900 # 15 mins
       # No retries.
       container:
         image: "{{ workflow.parameters.image-name }}:{{ workflow.parameters.image-tag }}"

--- a/templates/ls-lulc-classify-annual.yaml
+++ b/templates/ls-lulc-classify-annual.yaml
@@ -138,3 +138,11 @@ spec:
           # - "https://s3.us-west-2.amazonaws.com/data.ldn.auspatious.com/models/0-0-4/pacific/2020/lulc_random_forest_model_pacific_2020.joblib"
           - "{{ workflow.parameters.decimated }}"
           - "{{ workflow.parameters.overwrite }}"
+          - --memory-limit
+          - "10GB"
+          - --n-workers
+          - "2"
+          - --threads-per-worker
+          - "4"
+          - --xy-chunk-size
+          - "1024"


### PR DESCRIPTION
I implemented Fang's suggestion of doing a count first. This is a very quick check to see if using Tier 2, and 3 years of data is even needed. See here: https://github.com/auspatious/ldn-lulc/issues/26#issuecomment-4628000359

A tile that has too many scenes now uses the default:


```
(ldn-py3.12) ➜  ldn-lulc git:(classify-v2) ✗ poetry run ldn geomad run \
      --tile-id 021_034 \
      --region pacific \
      --year 2003 \
      --version 0-2-1
2026-06-05 14:34:05 | INFO | cli_geomad | ldn.cli_geomad:run:154 - tile=021_034 year=2003 version=0-2-1 region=pacific overwrite=False decimated=False all_bands=True mask_shadow=True memory=10GB workers=2 threads=16 chunk=2048 geomad_threads=10
2026-06-05 14:34:11 | INFO | cli_geomad | ldn.cli_geomad:count_scenes:83 - Found 80 (T1 not including T2) LS items for this tile/year
2026-06-05 14:34:11 | INFO | cli_geomad | ldn.cli_geomad:count_scenes:95 - Loaded 46 (T1 not including T2) LS items for this tile/year (grouped by solar_day)
2026-06-05 14:34:11 | INFO | cli_geomad | ldn.cli_geomad:run:167 - Scene count (tier 1) for tile/year: 46
2026-06-05 14:34:11 | INFO | cli_geomad | ldn.cli_geomad:run:170 - Scene count (46) is sufficient with T1 only.
```


A tile that is low on scenes adds the broader data (Fiji):
```
(ldn-py3.12) ➜  ldn-lulc git:(classify-v2) ✗ poetry run ldn geomad run \
      --tile-id 063_020 \
      --region pacific \
      --year 2003 \
      --version 0-2-1

2026-06-05 14:35:01 | INFO | cli_geomad | ldn.cli_geomad:run:154 - tile=063_020 year=2003 version=0-2-1 region=pacific overwrite=False decimated=False all_bands=True mask_shadow=True memory=10GB workers=2 threads=16 chunk=2048 geomad_threads=10
2026-06-05 14:35:03 | INFO | cli_geomad | ldn.cli_geomad:count_scenes:83 - Found 15 (T1 not including T2) LS items for this tile/year
2026-06-05 14:35:03 | INFO | cli_geomad | ldn.cli_geomad:count_scenes:95 - Loaded 14 (T1 not including T2) LS items for this tile/year (grouped by solar_day)
2026-06-05 14:35:03 | INFO | cli_geomad | ldn.cli_geomad:run:167 - Scene count (tier 1) for tile/year: 14
2026-06-05 14:35:03 | INFO | cli_geomad | ldn.cli_geomad:run:176 - Scene count (14) is below 20, trying with T2 too.
2026-06-05 14:35:05 | INFO | cli_geomad | ldn.cli_geomad:count_scenes:83 - Found 23 (T1 and T2) LS items for this tile/year
2026-06-05 14:35:05 | INFO | cli_geomad | ldn.cli_geomad:count_scenes:95 - Loaded 16 (T1 and T2) LS items for this tile/year (grouped by solar_day)
2026-06-05 14:35:05 | INFO | cli_geomad | ldn.cli_geomad:run:188 - Scene count with T2 (16) is still below 20. Adding LS7 buffered temporal search as well as T1 and T2 data.
Using 1-year buffered temporal search for LS7 era: 2002/2004
Item does not exist at https://dep-public-staging.s3.us-west-2.amazonaws.com/dep_ls_geomad/0-2-1/063/020/2003/dep_ls_geomad_063_020_2003.stac-item.json, processing tile.
2026-06-05 14:37:50 | INFO | geomad | ldn.geomad:run:425 - Found 100 LS items for this tile/year
2026-06-05 14:37:50 | INFO | geomad | ldn.geomad:run:427 - Loaded 65 LS items for this tile/year (grouped by solar_day)
```